### PR TITLE
Fix ServiceError usage in LoginUserManager

### DIFF
--- a/core/login_user_manager.py
+++ b/core/login_user_manager.py
@@ -65,7 +65,11 @@ class LoginUserManager(IBackupable):
             )
         except subprocess.CalledProcessError as e:
             stderr_text = e.stderr.decode('utf-8') if isinstance(e.stderr, bytes) else str(e.stderr)
-            raise ServiceError(f"Failed to change password for system user '{username}': {stderr_text}")
+            raise ServiceError(
+                "chpasswd",
+                f"change password for system user '{username}'",
+                stderr_text,
+            )
 
 
 


### PR DESCRIPTION
## Summary
- Fix ServiceError call in `change_user_password` to pass service and operation details separately

## Testing
- `python -m py_compile core/login_user_manager.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ae6ce809c8331baef879cc33b0c4c