### PR TITLE
Enforce API secret key configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ This is the original shell-based installer. It is still functional but no longer
 bash <(curl -Ls https://raw.githubusercontent.com/smaghili/openvpn/main/install.sh)
 ```
 
+### API Secret Key
+
+Before starting the API server, set a secret key via the `API_SECRET_KEY` environment variable:
+
+```bash
+export API_SECRET_KEY="your-strong-secret-key"
+```
+
+The application will fail to start if this variable is missing.
+
 ---
 
 - **Main idea inspired by:** [angristan/openvpn-install](https://github.com/angristan/openvpn-install)

--- a/api/app.py
+++ b/api/app.py
@@ -25,7 +25,10 @@ def create_app() -> Flask:
     Frontend web panel has been removed - only REST API is available.
     """
     app = Flask(__name__)
-    app.config['SECRET_KEY'] = os.environ.get('API_SECRET_KEY', 'dev-secret-key-change-in-production')
+    secret_key = os.environ.get('API_SECRET_KEY')
+    if not secret_key:
+        raise RuntimeError('API_SECRET_KEY environment variable is required')
+    app.config['SECRET_KEY'] = secret_key
     
     CORS(app)
     


### PR DESCRIPTION
## Summary
- Remove default dev secret key and require API_SECRET_KEY for startup
- Document API_SECRET_KEY environment variable in installation instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ae942b0d48331ab609fba6512d680