### PR TITLE
Refactor API app for package execution

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -4,20 +4,15 @@ import sys
 from flask import Flask, jsonify
 from flask_cors import CORS
 
-real_script_path = os.path.realpath(__file__)
-project_root = os.path.abspath(os.path.join(os.path.dirname(real_script_path), '..'))
-os.chdir(project_root)
-sys.path.insert(0, project_root)
-
-from api.routes.user_routes import user_bp
-from api.routes.quota_routes import quota_bp  
-from api.routes.system_routes import system_bp
-from api.routes.auth_routes import auth_bp
-from api.routes.admin_routes import admin_bp
-from api.routes.permission_routes import permission_bp
-from api.routes.profile_routes import profile_bp
-from api.middleware.jwt_middleware import JWTMiddleware
-from api.middleware.error_handler import ErrorHandler
+from .routes.user_routes import user_bp
+from .routes.quota_routes import quota_bp
+from .routes.system_routes import system_bp
+from .routes.auth_routes import auth_bp
+from .routes.admin_routes import admin_bp
+from .routes.permission_routes import permission_bp
+from .routes.profile_routes import profile_bp
+from .middleware.jwt_middleware import JWTMiddleware
+from .middleware.error_handler import ErrorHandler
 
 def create_app() -> Flask:
     """
@@ -51,19 +46,19 @@ def create_app() -> Flask:
     @app.route('/profile/<profile_token>')
     def public_profile_view(profile_token):
         """Public profile view - delegate to profile routes."""
-        from api.routes.profile_routes import public_profile_view as profile_view
+        from .routes.profile_routes import public_profile_view as profile_view
         return profile_view(profile_token)
     
     @app.route('/profile/<profile_token>/data')
     def public_profile_data(profile_token):
         """Public profile data API - delegate to profile routes."""
-        from api.routes.profile_routes import public_profile_data as profile_data
+        from .routes.profile_routes import public_profile_data as profile_data
         return profile_data(profile_token)
     
     @app.route('/profile/<profile_token>/config.ovpn')
     def download_ovpn_config(profile_token):
         """Download OpenVPN config - delegate to profile routes."""
-        from api.routes.profile_routes import download_ovpn_config as download_config
+        from .routes.profile_routes import download_ovpn_config as download_config
         return download_config(profile_token)
     
     # API-only server - no frontend routes
@@ -86,16 +81,21 @@ def create_app() -> Flask:
     
     return app
 
-if __name__ == '__main__':
+
+def main() -> None:
     if os.geteuid() != 0:
         print("API server must be run as root for OpenVPN operations.")
         sys.exit(1)
-        
+
     app = create_app()
     port = int(os.environ.get('API_PORT', 5000))
     print(f"🚀 Starting OpenVPN Manager API Server on http://0.0.0.0:{port}")
     print(f"🔗 API Endpoints: http://YOUR_IP:{port}/api")
     print(f"📊 Health Check: http://YOUR_IP:{port}/api/health")
-    
+
     from waitress import serve
     serve(app, host='0.0.0.0', port=port, threads=4)
+
+
+if __name__ == '__main__':
+    main()

--- a/run_api.py
+++ b/run_api.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+from api.app import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- remove manual sys.path tweaks and switch to package-relative imports in API app
- add `main()` helper and lightweight `run_api.py` entrypoint for running the server

## Testing
- `python -m py_compile api/app.py run_api.py`
- `python -m api.app & sleep 3; kill $!`


------
https://chatgpt.com/codex/tasks/task_b_689ae9413b5c8331ad16425006c24758