### PR TITLE
docs: remove obsolete monitor test reference

### DIFF
--- a/README-MONITORING.md
+++ b/README-MONITORING.md
@@ -190,16 +190,9 @@ sudo journalctl -u openvpn-monitor.service -n 50
 
 ## 🧪 Testing
 
-Run the comprehensive test suite:
-```bash
-python3 scripts/test_monitor.py
-```
-
-Tests include:
-- ✅ Status parsing with various formats
-- ✅ Database transaction handling
-- ✅ Configuration management
-- ✅ Error handling scenarios
+This legacy monitoring system does not include an automated test suite.
+To verify functionality, deploy the monitor service and confirm expected
+logging and disconnection behavior via system logs and the database.
 
 ## 📈 Performance Characteristics
 
@@ -220,7 +213,7 @@ Tests include:
 ## 📝 License & Support
 
 This monitoring system is part of the OpenVPN management project.
-For issues or questions, check the logs and test suite first.
+For issues or questions, check the logs first.
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify that the legacy TCP monitor has no automated test suite
- update support instructions to refer users to logs instead of tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_689ae8e7d3f48331a63b6ea309b23163