### PR TITLE
Use ID-based lookup for profile link

### DIFF
--- a/api/routes/profile_routes.py
+++ b/api/routes/profile_routes.py
@@ -78,7 +78,7 @@ def get_profile_link(user_id):
         # Check if user exists and admin has access
         db = Database()
         user_repo = UserRepository(db)
-        user = user_repo.find_user_by_username(str(user_id))
+        user = user_repo.get_user_by_id(user_id)
         
         if not user:
             return jsonify({

--- a/tests/test_profile_routes.py
+++ b/tests/test_profile_routes.py
@@ -1,0 +1,89 @@
+import importlib
+import os
+import sys
+from unittest.mock import patch
+
+from flask import Flask
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def _load_profile_routes():
+    """Import profile_routes with authentication decorators patched."""
+
+    from functools import wraps
+
+    def fake_require_auth(f):
+        @wraps(f)
+        def wrapper(*args, **kwargs):
+            from flask import g
+            g.current_admin = {"admin_id": 1, "role": "admin"}
+            return f(*args, **kwargs)
+
+        return wrapper
+
+    def fake_require_permission(_):
+        def decorator(f):
+            return f
+
+        return decorator
+
+    with patch(
+        "api.middleware.jwt_middleware.JWTMiddleware.require_auth",
+        fake_require_auth,
+    ), patch(
+        "api.middleware.jwt_middleware.JWTMiddleware.require_permission",
+        fake_require_permission,
+    ):
+        module = importlib.reload(
+            importlib.import_module("api.routes.profile_routes")
+        )
+
+    return module
+
+
+def _create_test_app(profile_routes_module):
+    app = Flask(__name__)
+    app.register_blueprint(
+        profile_routes_module.profile_bp, url_prefix="/api/profile"
+    )
+    return app
+
+
+def test_get_profile_link_calls_get_user_by_id():
+    profile_routes = _load_profile_routes()
+    app = _create_test_app(profile_routes)
+    client = app.test_client()
+
+    with patch.object(profile_routes, "get_security_service"), patch.object(
+        profile_routes, "Database"
+    ), patch.object(profile_routes, "UserRepository") as mock_repo:
+        repo_instance = mock_repo.return_value
+        repo_instance.get_user_by_id.return_value = {
+            "id": 1,
+            "created_by": 1,
+            "profile_token": "token",
+        }
+
+        response = client.get("/api/profile/users/1/profile-link")
+
+        assert response.status_code == 200
+        repo_instance.get_user_by_id.assert_called_once_with(1)
+
+
+def test_get_profile_link_user_not_found():
+    profile_routes = _load_profile_routes()
+    app = _create_test_app(profile_routes)
+    client = app.test_client()
+
+    with patch.object(profile_routes, "get_security_service"), patch.object(
+        profile_routes, "Database"
+    ), patch.object(profile_routes, "UserRepository") as mock_repo:
+        repo_instance = mock_repo.return_value
+        repo_instance.get_user_by_id.return_value = None
+
+        response = client.get("/api/profile/users/99/profile-link")
+
+        assert response.status_code == 404
+        repo_instance.get_user_by_id.assert_called_once_with(99)
+


### PR DESCRIPTION
## Summary
- Use `get_user_by_id` instead of username lookup in profile link endpoint
- Add tests for `get_profile_link` covering success and not-found cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689ae8e5be4c833183ebf00459012113