### PR TITLE
Resolve db_file assignment conflict in disconnect script

### DIFF
--- a/scripts/on_disconnect.py
+++ b/scripts/on_disconnect.py
@@ -63,7 +63,8 @@ def update_traffic_usage():
 
     try:
         # Direct database connection to avoid circular imports
-        db_file = VPNPaths.get_database_file()
+        # Allow override via environment variable if provided
+        db_file = os.environ.get("OPENVPN_DB_FILE") or VPNPaths.get_database_file()
         
         if not os.path.exists(db_file):
             # If database doesn't exist, just log to file


### PR DESCRIPTION
## Summary
- allow on_disconnect to respect `OPENVPN_DB_FILE` env override
- default to `VPNPaths.get_database_file()` when env var is unset

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689aee140e048331b2fa931c6baf90bc