### PR TITLE
Harden validation and backup processes

### DIFF
--- a/core/exceptions.py
+++ b/core/exceptions.py
@@ -3,6 +3,8 @@ Custom exception classes for VPN Manager.
 Provides specific error handling and better debugging.
 """
 
+from typing import Optional
+
 class VPNManagerError(Exception):
     """Base exception for VPN Manager operations."""
     pass
@@ -59,13 +61,28 @@ class ServiceError(VPNManagerError):
         super().__init__(f"Service '{service_name}' {operation} failed: {reason}")
 
 class ValidationError(VPNManagerError):
-    """Raised when input validation fails."""
-    
-    def __init__(self, field: str, value: str, reason: str):
-        self.field = field
-        self.value = value
-        self.reason = reason
-        super().__init__(f"Validation failed for {field}='{value}': {reason}")
+    """Raised when input validation fails.
+
+    This exception supports two calling patterns:
+
+    1. ``ValidationError("message")`` – for simple validation messages.
+    2. ``ValidationError(field, value, reason)`` – structured details about the
+       failing field.
+    """
+
+    def __init__(self, field_or_message: str, value: Optional[str] = None, reason: Optional[str] = None):
+        if value is None and reason is None:
+            message = field_or_message
+            self.field = None
+            self.value = None
+            self.reason = message
+        else:
+            message = f"Validation failed for {field_or_message}='{value}': {reason}"
+            self.field = field_or_message
+            self.value = value
+            self.reason = reason
+
+        super().__init__(message)
 
 class AuthenticationError(VPNManagerError):
     """Raised when authentication fails."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Python requirements for VPN Manager project
 # sqlite3 is built-in, but others may be needed for future features
-bcrypt
-pyopenssl
-flask
-flask-cors
-pyjwt
+bcrypt==4.0.1
+pyopenssl==23.2.0
+flask==2.3.3
+flask-cors==4.0.0
+pyjwt==2.8.0
 waitress==2.1.2

--- a/service/admin_service.py
+++ b/service/admin_service.py
@@ -201,7 +201,7 @@ class AdminService:
         if admin_role == 'admin':
             return True
         
-        user = self.user_repo.find_user_by_username(str(vpn_user_id))
+        user = self.user_repo.get_user_by_id(vpn_user_id)
         if not user:
             return False
         

--- a/service/security_service.py
+++ b/service/security_service.py
@@ -34,7 +34,7 @@ class SecurityService:
         """
         Generate or retrieve profile token for VPN user.
         """
-        user = self.user_repo.find_user_by_username(str(user_id))
+        user = self.user_repo.get_user_by_id(user_id)
         if not user:
             raise ValidationError(f"User ID {user_id} not found")
         
@@ -63,7 +63,7 @@ class SecurityService:
         """
         Regenerate profile token and reset access stats.
         """
-        user = self.user_repo.find_user_by_username(str(user_id))
+        user = self.user_repo.get_user_by_id(user_id)
         if not user:
             raise ValidationError(f"User ID {user_id} not found")
         
@@ -90,7 +90,7 @@ class SecurityService:
         """
         Revoke profile access by removing token.
         """
-        user = self.user_repo.find_user_by_username(str(user_id))
+        user = self.user_repo.get_user_by_id(user_id)
         if not user:
             raise ValidationError(f"User ID {user_id} not found")
         
@@ -110,7 +110,7 @@ class SecurityService:
         """
         Get profile access statistics.
         """
-        user = self.user_repo.find_user_by_username(str(user_id))
+        user = self.user_repo.get_user_by_id(user_id)
         if not user:
             raise ValidationError(f"User ID {user_id} not found")
         

--- a/tests/test_backup_service.py
+++ b/tests/test_backup_service.py
@@ -1,0 +1,39 @@
+import io
+import os
+import sys
+import tarfile
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from core.backup_service import BackupService
+from core.exceptions import RestoreError
+
+
+def test_safe_extract_prevents_path_traversal(tmp_path):
+    malicious_tar = tmp_path / "mal.tar.gz"
+    with tarfile.open(malicious_tar, "w:gz") as tar:
+        info = tarfile.TarInfo(name="../evil.txt")
+        data = b"hello"
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+
+    service = BackupService([])
+    with tarfile.open(malicious_tar, "r:gz") as tar:
+        with pytest.raises(RestoreError):
+            service._safe_extract(tar, path=tmp_path)
+
+
+def test_safe_extract_valid(tmp_path):
+    good_tar = tmp_path / "good.tar.gz"
+    with tarfile.open(good_tar, "w:gz") as tar:
+        info = tarfile.TarInfo(name="good.txt")
+        data = b"hi"
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+
+    service = BackupService([])
+    with tarfile.open(good_tar, "r:gz") as tar:
+        service._safe_extract(tar, path=tmp_path)
+
+    assert (tmp_path / "good.txt").read_text() == "hi"


### PR DESCRIPTION
## Summary
- Allow `ValidationError` to accept either a simple message or detailed field/value/reason data
- Use ID-based lookups for security and admin services
- Replace generic backup exceptions with `BackupError`/`RestoreError`, add safe extraction, and pin dependency versions
- Add tests covering secure backup extraction

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689aef8da8e08331bb09d3ddb20f6aeb