### PR TITLE
Improve middleware setup and logging

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -15,75 +15,79 @@ from .middleware.jwt_middleware import JWTMiddleware
 from .middleware.error_handler import ErrorHandler
 from .middleware.auth_middleware import AuthMiddleware
 
+
 def create_app() -> Flask:
     """
     Creates and configures the Flask application with API endpoints only.
     Frontend web panel has been removed - only REST API is available.
     """
     app = Flask(__name__)
-    secret_key = os.environ.get('API_SECRET_KEY')
+    secret_key = os.environ.get("API_SECRET_KEY")
     if not secret_key:
-        raise RuntimeError('API_SECRET_KEY environment variable is required')
-    app.config['SECRET_KEY'] = secret_key
-    
+        raise RuntimeError("API_SECRET_KEY environment variable is required")
+    app.config["SECRET_KEY"] = secret_key
+
     CORS(app)
-    
-      AuthMiddleware.init_app(app)
-      JWTMiddleware.init_app(app)
-      ErrorHandler.init_app(app)
-    
+
+    AuthMiddleware.init_app(app)
+    JWTMiddleware.init_app(app)
+    ErrorHandler.init_app(app)
+
     # API routes
-    app.register_blueprint(auth_bp, url_prefix='/api/auth')
-    app.register_blueprint(admin_bp, url_prefix='/api/admins')
-    app.register_blueprint(permission_bp, url_prefix='/api/permissions')
-    app.register_blueprint(user_bp, url_prefix='/api/users')
-    app.register_blueprint(quota_bp, url_prefix='/api/quota')
-    app.register_blueprint(system_bp, url_prefix='/api/system')
-    
+    app.register_blueprint(auth_bp, url_prefix="/api/auth")
+    app.register_blueprint(admin_bp, url_prefix="/api/admins")
+    app.register_blueprint(permission_bp, url_prefix="/api/permissions")
+    app.register_blueprint(user_bp, url_prefix="/api/users")
+    app.register_blueprint(quota_bp, url_prefix="/api/quota")
+    app.register_blueprint(system_bp, url_prefix="/api/system")
+
     # Profile routes
-    app.register_blueprint(profile_bp, url_prefix='/api/profile')
-    
-    @app.route('/api/health')
+    app.register_blueprint(profile_bp, url_prefix="/api/profile")
+
+    @app.route("/api/health")
     def health_check():
-        return {'status': 'healthy', 'message': 'OpenVPN Manager API is running'}
-    
+        return {"status": "healthy", "message": "OpenVPN Manager API is running"}
+
     # Public profile routes (no authentication required)
-    @app.route('/profile/<profile_token>')
+    @app.route("/profile/<profile_token>")
     def public_profile_view(profile_token):
         """Public profile view - delegate to profile routes."""
         from .routes.profile_routes import public_profile_view as profile_view
+
         return profile_view(profile_token)
-    
-    @app.route('/profile/<profile_token>/data')
+
+    @app.route("/profile/<profile_token>/data")
     def public_profile_data(profile_token):
         """Public profile data API - delegate to profile routes."""
         from .routes.profile_routes import public_profile_data as profile_data
+
         return profile_data(profile_token)
-    
-    @app.route('/profile/<profile_token>/config.ovpn')
+
+    @app.route("/profile/<profile_token>/config.ovpn")
     def download_ovpn_config(profile_token):
         """Download OpenVPN config - delegate to profile routes."""
         from .routes.profile_routes import download_ovpn_config as download_config
+
         return download_config(profile_token)
-    
+
     # API-only server - no frontend routes
-    @app.route('/')
+    @app.route("/")
     def api_info():
         """API information endpoint"""
         return {
-            'message': 'OpenVPN Manager API Server',
-            'version': '2.0.0',
-            'status': 'running',
-            'endpoints': {
-                'health': '/api/health',
-                'auth': '/api/auth/*',
-                'users': '/api/users/*',
-                'system': '/api/system/*',
-                'profiles': '/api/profile/*'
+            "message": "OpenVPN Manager API Server",
+            "version": "2.0.0",
+            "status": "running",
+            "endpoints": {
+                "health": "/api/health",
+                "auth": "/api/auth/*",
+                "users": "/api/users/*",
+                "system": "/api/system/*",
+                "profiles": "/api/profile/*",
             },
-            'note': 'Web panel has been removed - API only'
+            "note": "Web panel has been removed - API only",
         }
-    
+
     return app
 
 
@@ -93,14 +97,15 @@ def main() -> None:
         sys.exit(1)
 
     app = create_app()
-    port = int(os.environ.get('API_PORT', 5000))
+    port = int(os.environ.get("API_PORT", 5000))
     print(f"🚀 Starting OpenVPN Manager API Server on http://0.0.0.0:{port}")
     print(f"🔗 API Endpoints: http://YOUR_IP:{port}/api")
     print(f"📊 Health Check: http://YOUR_IP:{port}/api/health")
 
     from waitress import serve
-    serve(app, host='0.0.0.0', port=port, threads=4)
+
+    serve(app, host="0.0.0.0", port=port, threads=4)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/core/openvpn_manager.py
+++ b/core/openvpn_manager.py
@@ -3,6 +3,7 @@ import subprocess
 import shutil
 import json
 import logging
+from contextlib import contextmanager
 from typing import Dict, Any, List, Optional
 from .backup_interface import IBackupable
 from config.shared_config import CLIENT_TEMPLATE, USER_CERTS_TEMPLATE
@@ -14,7 +15,7 @@ from core.exceptions import (
     InstallationError,
     CertificateGenerationError,
     ServiceError,
-    ConfigurationError
+    ConfigurationError,
 )
 
 LOG_LEVEL = os.environ.get("OPENVPN_MANAGER_LOG_LEVEL", "INFO").upper()
@@ -24,6 +25,17 @@ LOG_FORMAT = os.environ.get(
 )
 logging.basicConfig(level=getattr(logging, LOG_LEVEL, logging.INFO), format=LOG_FORMAT)
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def working_directory(path: str):
+    """Temporarily change the working directory within a context."""
+    prev_cwd = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(prev_cwd)
 
 
 class OpenVPNManager(IBackupable):
@@ -39,7 +51,7 @@ class OpenVPNManager(IBackupable):
     PKI_DIR = config.PKI_DIR
     FIREWALL_RULES_V4 = config.FIREWALL_RULES_V4
     SETTINGS_FILE = config.SETTINGS_FILE
-    
+
     def __init__(self) -> None:
         self.settings: Dict[str, Any] = {}
         self._load_settings()
@@ -47,20 +59,20 @@ class OpenVPNManager(IBackupable):
     def _load_settings(self) -> None:
         if os.path.exists(self.SETTINGS_FILE):
             try:
-                with open(self.SETTINGS_FILE, 'r') as f:
+                with open(self.SETTINGS_FILE, "r") as f:
                     self.settings = json.load(f)
             except (json.JSONDecodeError, IOError) as e:
                 logger.warning("⚠️  Warning: Could not load settings file: %s", e)
 
     def _save_settings(self) -> None:
         os.makedirs(self.OPENVPN_DIR, exist_ok=True)
-        with open(self.SETTINGS_FILE, 'w') as f:
+        with open(self.SETTINGS_FILE, "w") as f:
             json.dump(self.settings, f, indent=4)
 
     def install_openvpn(self, settings: Dict[str, Any]) -> None:
         logger.info("▶️  Starting OpenVPN installation...")
         self.settings = settings
-        
+
         self._install_prerequisites()
         self._setup_pki()
         self._generate_server_configs()
@@ -70,125 +82,187 @@ class OpenVPNManager(IBackupable):
         if self.settings.get("dns") == "2":
             self._setup_unbound()
         self._start_openvpn_services()
-        
+
         self._save_settings()
 
     def _install_prerequisites(self) -> None:
-        # This method remains unchanged
         logger.info("[1/7] Installing prerequisites...")
-        packages = ["openvpn", "easy-rsa", "iptables-persistent", "openssl", "ca-certificates", "curl", "libpam-pwquality"]
+        packages = [
+            "openvpn",
+            "easy-rsa",
+            "iptables-persistent",
+            "openssl",
+            "ca-certificates",
+            "curl",
+            "libpam-pwquality",
+        ]
         if self.settings.get("dns") == "2":
             packages.append("unbound")
 
+        def _run(cmd: List[str], **kwargs) -> None:
+            try:
+                result = subprocess.run(
+                    cmd, check=True, capture_output=True, text=True, **kwargs
+                )
+                if result.stdout:
+                    logger.debug(result.stdout.strip())
+                if result.stderr:
+                    logger.debug(result.stderr.strip())
+            except subprocess.CalledProcessError as exc:
+                if exc.stdout:
+                    logger.error(exc.stdout.strip())
+                if exc.stderr:
+                    logger.error(exc.stderr.strip())
+                raise
+
         logger.info("   └── Updating package lists...")
-        subprocess.run(["apt-get", "update"], check=True, capture_output=True)
+        _run(["apt-get", "update"])
 
         logger.info("   └── Configuring firewall persistence...")
-        subprocess.run(["debconf-set-selections"], input="iptables-persistent iptables-persistent/autosave_v4 boolean true\n",
-                      text=True, check=True, capture_output=True)
-        subprocess.run(["debconf-set-selections"], input="iptables-persistent iptables-persistent/autosave_v6 boolean true\n",
-                      text=True, check=True, capture_output=True)
+        _run(
+            ["debconf-set-selections"],
+            input="iptables-persistent iptables-persistent/autosave_v4 boolean true\n",
+            text=True,
+        )
+        _run(
+            ["debconf-set-selections"],
+            input="iptables-persistent iptables-persistent/autosave_v6 boolean true\n",
+            text=True,
+        )
 
         logger.info("   └── Installing %d packages...", len(packages))
         env = os.environ.copy()
         env["DEBIAN_FRONTEND"] = "noninteractive"
-        subprocess.run(["apt-get", "install", "-y"] + packages, check=True, capture_output=True, env=env)
+        _run(["apt-get", "install", "-y"] + packages, env=env)
         logger.info("   ✅ Prerequisites installed")
 
-
     def _setup_pki(self) -> None:
-        # This method remains unchanged
         logger.info("[2/7] Setting up Public Key Infrastructure (PKI)...")
 
         logger.info("   └── Preparing Easy-RSA environment...")
         if os.path.exists(self.EASYRSA_DIR):
-             shutil.rmtree(self.EASYRSA_DIR)
+            shutil.rmtree(self.EASYRSA_DIR)
         shutil.copytree("/usr/share/easy-rsa/", self.EASYRSA_DIR)
         easyrsa_script_path = os.path.join(self.EASYRSA_DIR, "easyrsa")
         os.chmod(easyrsa_script_path, 0o755)
 
-        os.chdir(self.EASYRSA_DIR)
-        
-        with open("vars", "w") as f:
-            f.write('set_var EASYRSA_ALGO "ec"\n')
-            f.write('set_var EASYRSA_CURVE "prime256v1"\n')
+        with working_directory(self.EASYRSA_DIR):
+            with open("vars", "w") as f:
+                f.write('set_var EASYRSA_ALGO "ec"\n')
+                f.write('set_var EASYRSA_CURVE "prime256v1"\n')
 
-        import random
-        import string
-        server_cn = f"cn_{''.join(random.choices(string.ascii_letters + string.digits, k=16))}"
-        server_name = f"server_{''.join(random.choices(string.ascii_letters + string.digits, k=16))}"
-        
-        logger.info("   └── Initializing PKI structure...")
-        subprocess.run(["./easyrsa", "init-pki"], check=True, capture_output=True)
-        
-        logger.info("   └── Generating Certificate Authority...")
-        subprocess.run(["./easyrsa", "--batch", f"--req-cn={server_cn}", "build-ca", "nopass"], check=True, capture_output=True, env={**os.environ, "EASYRSA_CA_EXPIRE": "3650"})
-        
-        logger.info("   └── Creating server certificate...")
-        subprocess.run(["./easyrsa", "--batch", "build-server-full", server_name, "nopass"], check=True, capture_output=True, env={**os.environ, "EASYRSA_CERT_EXPIRE": "3650"})
-        
-        logger.info("   └── Generating certificate revocation list...")
-        subprocess.run(["./easyrsa", "gen-crl"], check=True, capture_output=True, env={**os.environ, "EASYRSA_CRL_DAYS": "3650"})
-        
-        logger.info("   └── Creating TLS encryption key...")
-        subprocess.run(["openvpn", "--genkey", "--secret", "/etc/openvpn/tls-crypt.key"], check=True, capture_output=True)
-        # Copy to server directory as well
-        if os.path.exists("/etc/openvpn/tls-crypt.key"):
+            import random
+            import string
+
+            server_cn = f"cn_{''.join(random.choices(string.ascii_letters + string.digits, k=16))}"
+            server_name = f"server_{''.join(random.choices(string.ascii_letters + string.digits, k=16))}"
+
+            logger.info("   └── Initializing PKI structure...")
+            subprocess.run(["./easyrsa", "init-pki"], check=True, capture_output=True)
+
+            logger.info("   └── Generating Certificate Authority...")
+            subprocess.run(
+                ["./easyrsa", "--batch", f"--req-cn={server_cn}", "build-ca", "nopass"],
+                check=True,
+                capture_output=True,
+                env={**os.environ, "EASYRSA_CA_EXPIRE": "3650"},
+            )
+
+            logger.info("   └── Creating server certificate...")
+            subprocess.run(
+                ["./easyrsa", "--batch", "build-server-full", server_name, "nopass"],
+                check=True,
+                capture_output=True,
+                env={**os.environ, "EASYRSA_CERT_EXPIRE": "3650"},
+            )
+
+            logger.info("   └── Generating certificate revocation list...")
+            subprocess.run(
+                ["./easyrsa", "gen-crl"],
+                check=True,
+                capture_output=True,
+                env={**os.environ, "EASYRSA_CRL_DAYS": "3650"},
+            )
+
+            logger.info("   └── Creating TLS encryption key...")
+            subprocess.run(
+                ["openvpn", "--genkey", "--secret", "/etc/openvpn/tls-crypt.key"],
+                check=True,
+                capture_output=True,
+            )
+            if os.path.exists("/etc/openvpn/tls-crypt.key"):
+                os.makedirs("/etc/openvpn/server", exist_ok=True)
+                shutil.copy("/etc/openvpn/tls-crypt.key", "/etc/openvpn/server/")
+
+            logger.info("   └── Installing certificates...")
+            shutil.copy(f"{self.PKI_DIR}/ca.crt", "/etc/openvpn/")
+            shutil.copy(f"{self.PKI_DIR}/private/ca.key", "/etc/openvpn/")
+            shutil.copy(
+                f"{self.PKI_DIR}/issued/{server_name}.crt",
+                "/etc/openvpn/server-cert.crt",
+            )
+            shutil.copy(
+                f"{self.PKI_DIR}/private/{server_name}.key",
+                "/etc/openvpn/server-cert.key",
+            )
+            shutil.copy(f"{self.PKI_DIR}/crl.pem", "/etc/openvpn/")
+            os.chmod("/etc/openvpn/crl.pem", 0o644)
+
             os.makedirs("/etc/openvpn/server", exist_ok=True)
-            shutil.copy("/etc/openvpn/tls-crypt.key", "/etc/openvpn/server/")
+            shutil.copy(f"{self.PKI_DIR}/ca.crt", "/etc/openvpn/server/")
+            shutil.copy(
+                f"{self.PKI_DIR}/issued/{server_name}.crt",
+                "/etc/openvpn/server/server-cert.crt",
+            )
+            shutil.copy(
+                f"{self.PKI_DIR}/private/{server_name}.key",
+                "/etc/openvpn/server/server-cert.key",
+            )
+            shutil.copy(f"{self.PKI_DIR}/crl.pem", "/etc/openvpn/server/")
+            os.chmod("/etc/openvpn/server/crl.pem", 0o644)
 
-        logger.info("   └── Installing certificates...")
-        # Copy to /etc/openvpn/ (system directory) 
-        shutil.copy(f"{self.PKI_DIR}/ca.crt", "/etc/openvpn/")
-        shutil.copy(f"{self.PKI_DIR}/private/ca.key", "/etc/openvpn/")
-        shutil.copy(f"{self.PKI_DIR}/issued/{server_name}.crt", "/etc/openvpn/server-cert.crt")
-        shutil.copy(f"{self.PKI_DIR}/private/{server_name}.key", "/etc/openvpn/server-cert.key")
-        shutil.copy(f"{self.PKI_DIR}/crl.pem", "/etc/openvpn/")
-        os.chmod("/etc/openvpn/crl.pem", 0o644)
-        
-        # Copy to /etc/openvpn/server/ (for systemd service)
-        os.makedirs("/etc/openvpn/server", exist_ok=True)
-        shutil.copy(f"{self.PKI_DIR}/ca.crt", "/etc/openvpn/server/")
-        shutil.copy(f"{self.PKI_DIR}/issued/{server_name}.crt", "/etc/openvpn/server/server-cert.crt")
-        shutil.copy(f"{self.PKI_DIR}/private/{server_name}.key", "/etc/openvpn/server/server-cert.key")
-        shutil.copy(f"{self.PKI_DIR}/crl.pem", "/etc/openvpn/server/")
-        os.chmod("/etc/openvpn/server/crl.pem", 0o644)
-        
-        # Also copy to data directory for backup
-        shutil.copy(f"{self.PKI_DIR}/ca.crt", self.OPENVPN_DIR)
-        shutil.copy(f"{self.PKI_DIR}/issued/{server_name}.crt", f"{self.OPENVPN_DIR}/server-cert.crt")
-        shutil.copy(f"{self.PKI_DIR}/private/{server_name}.key", f"{self.OPENVPN_DIR}/server-cert.key")
-        shutil.copy(f"{self.PKI_DIR}/crl.pem", self.OPENVPN_DIR)
-        logger.info("   ✅ PKI setup complete")
+            shutil.copy(f"{self.PKI_DIR}/ca.crt", self.OPENVPN_DIR)
+            shutil.copy(
+                f"{self.PKI_DIR}/issued/{server_name}.crt",
+                f"{self.OPENVPN_DIR}/server-cert.crt",
+            )
+            shutil.copy(
+                f"{self.PKI_DIR}/private/{server_name}.key",
+                f"{self.OPENVPN_DIR}/server-cert.key",
+            )
+            shutil.copy(f"{self.PKI_DIR}/crl.pem", self.OPENVPN_DIR)
+            logger.info("   ✅ PKI setup complete")
 
     def _generate_server_configs(self) -> None:
         logger.info("[3/7] Generating server configurations...")
 
         logger.info("   └── Creating directory structure...")
         os.makedirs(self.SERVER_CONFIG_DIR, exist_ok=True)
-        
+
         # Copy scripts to /etc/openvpn/scripts/ for better access
-        project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-        scripts_dir = os.path.join(project_root, 'scripts')
+        project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        scripts_dir = os.path.join(project_root, "scripts")
         openvpn_scripts_dir = "/etc/openvpn/scripts"
-        
+
         if os.path.exists(scripts_dir):
             logger.info("   └── Setting up monitoring scripts...")
             os.makedirs(openvpn_scripts_dir, exist_ok=True)
 
             # Copy scripts to OpenVPN directory
-            for script_name in ['on_connect.py', 'on_disconnect.py']:
+            for script_name in ["on_connect.py", "on_disconnect.py"]:
                 source_script = os.path.join(scripts_dir, script_name)
                 if os.path.exists(source_script):
-                    shutil.copy(source_script, os.path.join(openvpn_scripts_dir, script_name))
+                    shutil.copy(
+                        source_script, os.path.join(openvpn_scripts_dir, script_name)
+                    )
                     os.chmod(os.path.join(openvpn_scripts_dir, script_name), 0o755)
 
             # Set proper permissions
             os.chmod(openvpn_scripts_dir, 0o755)
 
             # Copy or link environment file for script access
-            env_source = os.path.join(project_root, '.env')
-            env_target = '/etc/openvpn/.env'
+            env_source = os.path.join(project_root, ".env")
+            env_target = "/etc/openvpn/.env"
             if os.path.exists(env_source):
                 try:
                     if os.path.islink(env_target) or os.path.exists(env_target):
@@ -203,14 +277,14 @@ class OpenVPNManager(IBackupable):
         db_dir = os.path.dirname(db_file)
         os.makedirs(db_dir, exist_ok=True)
         try:
-            shutil.chown(db_dir, user='nobody', group='nogroup')
+            shutil.chown(db_dir, user="nobody", group="nogroup")
             os.chmod(db_dir, 0o770)
         except Exception as e:
             print(f"   └── Warning: could not set permissions on {db_dir}: {e}")
 
         if os.path.exists(db_file) and not os.access(db_file, os.W_OK):
             try:
-                shutil.chown(db_file, user='nobody', group='nogroup')
+                shutil.chown(db_file, user="nobody", group="nogroup")
                 os.chmod(db_file, 0o660)
             except Exception as e:
                 print(f"   └── Warning: could not set permissions on {db_file}: {e}")
@@ -218,13 +292,13 @@ class OpenVPNManager(IBackupable):
         # Create required system directories
         system_dirs = [
             OpenVPNConstants.VAR_LOG_OPENVPN,
-            OpenVPNConstants.VAR_RUN_OPENVPN
+            OpenVPNConstants.VAR_RUN_OPENVPN,
         ]
-        
+
         for path in system_dirs:
             os.makedirs(path, exist_ok=True)
             shutil.chown(path, user="nobody", group="nogroup")
-        
+
         # CCD directory should be in the OpenVPN system directory
         os.makedirs(OpenVPNConstants.CCD_DIR, exist_ok=True)
         shutil.chown(OpenVPNConstants.CCD_DIR, user="nobody", group="nogroup")
@@ -234,7 +308,14 @@ class OpenVPNManager(IBackupable):
         logger.info("   └── Generating certificate-based server config...")
         base_config = self._get_base_config()
         cert_monitoring_config = self._get_monitoring_config(service_type="cert")
-        cert_config = base_config.format(port=self.settings["cert_port"], proto=self.settings["cert_proto"], extra_auth="") + cert_monitoring_config
+        cert_config = (
+            base_config.format(
+                port=self.settings["cert_port"],
+                proto=self.settings["cert_proto"],
+                extra_auth="",
+            )
+            + cert_monitoring_config
+        )
         # Write to /etc/openvpn/server/server-cert.conf for systemd service
         os.makedirs("/etc/openvpn/server", exist_ok=True)
         with open("/etc/openvpn/server/server-cert.conf", "w") as f:
@@ -270,16 +351,36 @@ class OpenVPNManager(IBackupable):
 
         logger.info("   └── Configuring NAT rules for certificate-based VPN...")
         check_command = f"iptables -t nat -C POSTROUTING -s 10.8.0.0/24 -o {net_interface} -j MASQUERADE"
-        if subprocess.run(check_command, shell=True, capture_output=True, text=True).returncode != 0:
-            subprocess.run(f"iptables -t nat -A POSTROUTING -s 10.8.0.0/24 -o {net_interface} -j MASQUERADE", shell=True, check=True)
+        if (
+            subprocess.run(
+                check_command, shell=True, capture_output=True, text=True
+            ).returncode
+            != 0
+        ):
+            subprocess.run(
+                f"iptables -t nat -A POSTROUTING -s 10.8.0.0/24 -o {net_interface} -j MASQUERADE",
+                shell=True,
+                check=True,
+            )
 
         logger.info("   └── Configuring NAT rules for login-based VPN...")
         check_command = f"iptables -t nat -C POSTROUTING -s 10.9.0.0/24 -o {net_interface} -j MASQUERADE"
-        if subprocess.run(check_command, shell=True, capture_output=True, text=True).returncode != 0:
-            subprocess.run(f"iptables -t nat -A POSTROUTING -s 10.9.0.0/24 -o {net_interface} -j MASQUERADE", shell=True, check=True)
+        if (
+            subprocess.run(
+                check_command, shell=True, capture_output=True, text=True
+            ).returncode
+            != 0
+        ):
+            subprocess.run(
+                f"iptables -t nat -A POSTROUTING -s 10.9.0.0/24 -o {net_interface} -j MASQUERADE",
+                shell=True,
+                check=True,
+            )
         logger.info("   └── Saving firewall rules...")
         os.makedirs(os.path.dirname(self.FIREWALL_RULES_V4), exist_ok=True)
-        subprocess.run(f"iptables-save > {self.FIREWALL_RULES_V4}", shell=True, check=True)
+        subprocess.run(
+            f"iptables-save > {self.FIREWALL_RULES_V4}", shell=True, check=True
+        )
         logger.info("   ✅ Firewall rules configured")
 
     def _enable_ip_forwarding(self) -> None:
@@ -299,7 +400,9 @@ class OpenVPNManager(IBackupable):
         # This method remains unchanged
         logger.info("[6/7] Configuring PAM for OpenVPN...")
         logger.info("   └── Setting up username/password authentication...")
-        pam_config = "auth required pam_unix.so shadow nodelay\naccount required pam_unix.so\n"
+        pam_config = (
+            "auth required pam_unix.so shadow nodelay\naccount required pam_unix.so\n"
+        )
         with open("/etc/pam.d/openvpn", "w") as f:
             f.write(pam_config)
         logger.info("   ✅ PAM authentication configured")
@@ -313,29 +416,37 @@ class OpenVPNManager(IBackupable):
         if not silent:
             logger.info("[7/7] Starting all services...")
             logger.info("   └── Reloading systemd daemon...")
-        
+
         subprocess.run(["systemctl", "daemon-reload"], check=True, capture_output=True)
-        
+
         services_to_manage = [
             "openvpn-server@server-cert",
-            "openvpn-server@server-login"
+            "openvpn-server@server-login",
         ]
-        
+
         for service in services_to_manage:
             if not silent:
                 logger.info("   └── Enabling %s...", service)
-            subprocess.run(["systemctl", "enable", service], check=True, capture_output=True)
+            subprocess.run(
+                ["systemctl", "enable", service], check=True, capture_output=True
+            )
             if not silent:
                 logger.info("   └── (Re)starting %s...", service)
-            subprocess.run(["systemctl", "restart", service], check=True, capture_output=True)
-        
+            subprocess.run(
+                ["systemctl", "restart", service], check=True, capture_output=True
+            )
+
         if not silent:
             logger.info("   ✅ All services started and enabled.")
 
     def create_user_certificate(self, username: Username) -> None:
         # This method remains unchanged
         os.chdir(self.EASYRSA_DIR)
-        subprocess.run(["./easyrsa", "--batch", "build-client-full", username, "nopass"], check=True, capture_output=True)
+        subprocess.run(
+            ["./easyrsa", "--batch", "build-client-full", username, "nopass"],
+            check=True,
+            capture_output=True,
+        )
 
     def revoke_user_certificate(self, username: Username) -> None:
         # This method remains unchanged
@@ -343,8 +454,18 @@ class OpenVPNManager(IBackupable):
         if not os.path.exists(cert_path):
             return
         os.chdir(self.EASYRSA_DIR)
-        subprocess.run(["./easyrsa", "--batch", "revoke", username], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        subprocess.run(["./easyrsa", "gen-crl"], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        subprocess.run(
+            ["./easyrsa", "--batch", "revoke", username],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        subprocess.run(
+            ["./easyrsa", "gen-crl"],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
         shutil.copy(f"{self.PKI_DIR}/crl.pem", self.OPENVPN_DIR)
         self._start_openvpn_services(silent=True)
 
@@ -355,25 +476,31 @@ class OpenVPNManager(IBackupable):
         user_key = self._read_file(f"{self.PKI_DIR}/private/{username}.key")
         tls_crypt_key = self._read_file("/etc/openvpn/tls-crypt.key")
 
-        user_specific_certs = USER_CERTS_TEMPLATE.format(user_cert=user_cert, user_key=user_key)
-        
+        user_specific_certs = USER_CERTS_TEMPLATE.format(
+            user_cert=user_cert, user_key=user_key
+        )
+
         return CLIENT_TEMPLATE.format(
             proto=self.settings.get("cert_proto", "udp"),
             server_ip=self.settings.get("public_ip"),
             port=self.settings.get("cert_port", "1194"),
             ca_cert=ca_cert,
             user_specific_certs=user_specific_certs,
-            tls_crypt_key=tls_crypt_key
+            tls_crypt_key=tls_crypt_key,
         )
 
     def get_shared_config(self) -> ConfigData:
         # This method remains unchanged
         ca_cert = self._read_file("/etc/openvpn/ca.crt")
-        
+
         if not os.path.exists(f"{self.PKI_DIR}/issued/main.crt"):
             os.chdir(self.EASYRSA_DIR)
-            subprocess.run(["./easyrsa", "--batch", "build-client-full", "main", "nopass"], check=True, capture_output=True)
-        
+            subprocess.run(
+                ["./easyrsa", "--batch", "build-client-full", "main", "nopass"],
+                check=True,
+                capture_output=True,
+            )
+
         main_cert = self._extract_certificate(f"{self.PKI_DIR}/issued/main.crt")
         main_key = self._read_file(f"{self.PKI_DIR}/private/main.key")
         tls_crypt_key = self._read_file("/etc/openvpn/tls-crypt.key")
@@ -413,7 +540,7 @@ tls-version-min 1.2
 <tls-crypt>
 {tls_crypt_key}
 </tls-crypt>"""
-        
+
         return config
 
     def uninstall_openvpn(self, silent: bool = False) -> None:
@@ -431,11 +558,15 @@ tls-version-min 1.2
             "openvpn-monitor",
             "openvpn-server@server-cert",
             "openvpn-server@server-login",
-            "openvpn@server"
+            "openvpn@server",
         ]
         for service in services_to_stop:
-            subprocess.run(["systemctl", "stop", service], check=False, capture_output=True)
-            subprocess.run(["systemctl", "disable", service], check=False, capture_output=True)
+            subprocess.run(
+                ["systemctl", "stop", service], check=False, capture_output=True
+            )
+            subprocess.run(
+                ["systemctl", "disable", service], check=False, capture_output=True
+            )
 
         if not silent:
             logger.info("   └── Removing service files...")
@@ -449,11 +580,11 @@ tls-version-min 1.2
         config_paths = [
             self.SETTINGS_FILE,
             "/etc/openvpn/server-cert.conf",
-            "/etc/openvpn/server-login.conf", 
+            "/etc/openvpn/server-login.conf",
             "/etc/openvpn/server/server-cert.conf",
             "/etc/openvpn/server/server-login.conf",
             "/etc/pam.d/openvpn",
-            self.FIREWALL_RULES_V4
+            self.FIREWALL_RULES_V4,
         ]
         for path in config_paths:
             if os.path.exists(path):
@@ -464,11 +595,11 @@ tls-version-min 1.2
         directories_to_remove = [
             self.OPENVPN_DIR,
             "/etc/openvpn/easy-rsa",
-            "/etc/openvpn/server", 
+            "/etc/openvpn/server",
             "/etc/openvpn/ccd",
             "/etc/openvpn/scripts",
             "/var/log/openvpn",
-            "/var/run/openvpn"
+            "/var/run/openvpn",
         ]
         for path in directories_to_remove:
             if os.path.exists(path):
@@ -478,11 +609,11 @@ tls-version-min 1.2
             logger.info("   └── Removing certificate files...")
         cert_files = [
             "/etc/openvpn/ca.crt",
-            "/etc/openvpn/ca.key", 
+            "/etc/openvpn/ca.key",
             "/etc/openvpn/server-cert.crt",
             "/etc/openvpn/server-cert.key",
             "/etc/openvpn/crl.pem",
-            "/etc/openvpn/tls-crypt.key"
+            "/etc/openvpn/tls-crypt.key",
         ]
         for path in cert_files:
             if os.path.exists(path):
@@ -496,9 +627,13 @@ tls-version-min 1.2
         packages = ["openvpn", "easy-rsa", "iptables-persistent"]
         if os.path.exists("/etc/unbound"):
             packages.append("unbound")
-        subprocess.run(["apt-get", "remove", "--purge", "-y"] + packages, check=True, capture_output=True)
+        subprocess.run(
+            ["apt-get", "remove", "--purge", "-y"] + packages,
+            check=True,
+            capture_output=True,
+        )
         subprocess.run(["apt-get", "autoremove", "-y"], check=True, capture_output=True)
-        
+
         if not silent:
             logger.info("✅ Complete uninstallation finished. All ports freed.")
 
@@ -511,26 +646,28 @@ tls-version-min 1.2
         services_to_stop = [
             "openvpn-uds-monitor",
             "openvpn-server@server-cert",
-            "openvpn-server@server-login"
+            "openvpn-server@server-login",
         ]
         for service in services_to_stop:
-            subprocess.run(["systemctl", "stop", service], check=False, capture_output=True)
+            subprocess.run(
+                ["systemctl", "stop", service], check=False, capture_output=True
+            )
 
     def post_restore(self) -> None:
         # This method remains unchanged
-        self._load_settings() 
+        self._load_settings()
         self._start_openvpn_services(silent=True)
 
     def _get_base_config(self) -> str:
         # Use VPNPaths for all certificate and key paths
         from config.paths import VPNPaths
-        
+
         dns_lines = {
             "1": "",
             "2": f'push "dhcp-option DNS 10.8.0.1"',
             "3": 'push "dhcp-option DNS 1.1.1.1"\npush "dhcp-option DNS 1.0.0.1"',
             "4": 'push "dhcp-option DNS 8.8.8.8"\npush "dhcp-option DNS 8.8.4.4"',
-            "5": 'push "dhcp-option DNS 94.140.14.14"\npush "dhcp-option DNS 94.140.15.15"'
+            "5": 'push "dhcp-option DNS 94.140.14.14"\npush "dhcp-option DNS 94.140.15.15"',
         }.get(self.settings.get("dns", "3"), "")
 
         return f"""port {{port}}
@@ -560,13 +697,13 @@ verb 3
 
     def _get_login_config(self) -> str:
         # Generate login-based server configuration
-        
+
         dns_lines = {
             "1": "",
             "2": f'push "dhcp-option DNS 10.9.0.1"',
             "3": 'push "dhcp-option DNS 1.1.1.1"\npush "dhcp-option DNS 1.0.0.1"',
             "4": 'push "dhcp-option DNS 8.8.8.8"\npush "dhcp-option DNS 8.8.4.4"',
-            "5": 'push "dhcp-option DNS 94.140.14.14"\npush "dhcp-option DNS 94.140.15.15"'
+            "5": 'push "dhcp-option DNS 94.140.14.14"\npush "dhcp-option DNS 94.140.15.15"',
         }.get(self.settings.get("dns", "3"), "")
 
         cipher_config = self.settings.get("cipher", "AES-256-GCM") + ":AES-128-GCM"
@@ -611,13 +748,13 @@ verb 3"""
 
     def _get_monitoring_config(self, service_type: str = "cert") -> str:
         """Returns the config lines needed for traffic monitoring with UDS."""
-        
+
         # Use different sockets for different services
         if service_type == "login":
             uds_socket = "/run/openvpn-server/ovpn-mgmt-login.sock"
         else:
             uds_socket = "/run/openvpn-server/ovpn-mgmt-cert.sock"
-        
+
         return f"""
 # --- Traffic Monitoring Config ---
 script-security 2
@@ -629,34 +766,40 @@ management {uds_socket} unix
     def _get_primary_interface(self) -> str:
         # This method remains unchanged
         try:
-            result = subprocess.run("ip route get 8.8.8.8 | awk '{print $5; exit}'", shell=True, capture_output=True, text=True, check=True)
+            result = subprocess.run(
+                "ip route get 8.8.8.8 | awk '{print $5; exit}'",
+                shell=True,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
             return result.stdout.strip()
         except Exception:
             return "eth0"
-            
+
     def _read_file(self, path: str) -> str:
         # This method remains unchanged
         if os.path.exists(path):
             with open(path, "r") as f:
                 return f.read().strip()
         return ""
-    
+
     def _extract_certificate(self, path: str) -> str:
         # This method remains unchanged
         if os.path.exists(path):
             with open(path, "r") as f:
                 content = f.read()
-                lines = content.split('\n')
+                lines = content.split("\n")
                 cert_lines = []
                 in_cert = False
                 for line in lines:
-                    if '-----BEGIN CERTIFICATE-----' in line:
+                    if "-----BEGIN CERTIFICATE-----" in line:
                         in_cert = True
                         cert_lines.append(line)
-                    elif '-----END CERTIFICATE-----' in line:
+                    elif "-----END CERTIFICATE-----" in line:
                         cert_lines.append(line)
                         break
                     elif in_cert:
                         cert_lines.append(line)
-                return '\n'.join(cert_lines)
+                return "\n".join(cert_lines)
         return ""

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -1,0 +1,39 @@
+import os
+from unittest.mock import patch
+from flask import Flask, jsonify
+
+from api.middleware.auth_middleware import AuthMiddleware
+
+
+def create_app():
+    app = Flask(__name__)
+    with patch.dict(os.environ, {"OPENVPN_API_KEY": "testkey"}):
+        AuthMiddleware.init_app(app)
+
+    @app.route("/protected")
+    @AuthMiddleware.require_auth
+    def protected():
+        return jsonify({"status": "ok"})
+
+    return app
+
+
+def test_missing_api_key():
+    app = create_app()
+    client = app.test_client()
+    response = client.get("/protected")
+    assert response.status_code == 401
+
+
+def test_invalid_api_key():
+    app = create_app()
+    client = app.test_client()
+    response = client.get("/protected", headers={"X-API-Key": "wrong"})
+    assert response.status_code == 401
+
+
+def test_valid_api_key():
+    app = create_app()
+    client = app.test_client()
+    response = client.get("/protected", headers={"X-API-Key": "testkey"})
+    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- fix middleware indentation in `api/app` so Auth, JWT, and error handlers register correctly
- add `working_directory` context manager and log subprocess outputs during prerequisite install
- test AuthMiddleware to ensure API key enforcement

## Testing
- `black --check api/app.py core/openvpn_manager.py tests/test_auth_middleware.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689b0d28c8208331bb853205306ecc1d