### PR TITLE
Ensure deploy script halts on pipeline errors

### DIFF
--- a/core/openvpn_manager.py
+++ b/core/openvpn_manager.py
@@ -122,12 +122,10 @@ class OpenVPNManager(IBackupable):
         _run(
             ["debconf-set-selections"],
             input="iptables-persistent iptables-persistent/autosave_v4 boolean true\n",
-            text=True,
         )
         _run(
             ["debconf-set-selections"],
             input="iptables-persistent iptables-persistent/autosave_v6 boolean true\n",
-            text=True,
         )
 
         logger.info("   └── Installing %d packages...", len(packages))


### PR DESCRIPTION
## Summary
- Enable `set -o pipefail` to detect failures in command pipelines
- Add explicit error handling for key generation commands in `deploy.sh`
- Remove redundant `text=True` when invoking `debconf-set-selections` to prevent subprocess argument conflicts

## Testing
- `bash -n deploy.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689b1c8a2c4083319f996712cf1e8a74