### PR TITLE
Extend UI i18n support and add Russian locale stub

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html dir="rtl">
+<html>
 <head>
 <meta charset="utf-8" />
-<title>Login</title>
+<title data-i18n="login_title"></title>
 <link rel="stylesheet" href="styles.css" />
 <script src="script.js"></script>
 </head>
@@ -12,8 +12,9 @@
 <div style="text-align:right;padding:1rem;">
 <button onclick="toggleTheme()" data-i18n="btn_theme"></button>
 <select id="langSelect" onchange="setLanguage(this.value)">
-<option value="fa">FA</option>
-<option value="en">EN</option>
+<option value="fa" data-i18n="lang_fa"></option>
+<option value="en" data-i18n="lang_en"></option>
+<option value="ru" data-i18n="lang_ru"></option>
 </select>
 </div>
 <div style="max-width:400px;margin:2rem auto;border:var(--border-style);padding:1rem;text-align:center;">

--- a/ui/openvpn.html
+++ b/ui/openvpn.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html dir="rtl">
+<html>
 <head>
 <meta charset="utf-8" />
-<title>OpenVPN Settings</title>
+<title data-i18n="openvpn_title"></title>
 <link rel="stylesheet" href="styles.css" />
 <script src="script.js"></script>
 </head>
@@ -14,8 +14,9 @@
 <h1 data-i18n="sidebar_title"></h1>
 <button onclick="toggleTheme()" data-i18n="btn_theme"></button>
 <select id="langSelect" onchange="setLanguage(this.value)">
-<option value="fa">FA</option>
-<option value="en">EN</option>
+<option value="fa" data-i18n="lang_fa"></option>
+<option value="en" data-i18n="lang_en"></option>
+<option value="ru" data-i18n="lang_ru"></option>
 </select>
 <ul>
 <li><a href="overview.html" data-i18n="nav_overview"></a></li>
@@ -37,13 +38,13 @@
 <section style="margin-top:1rem;">
 <h3 data-i18n="service_config"></h3>
 <label><span data-i18n="service_port"></span> <input type="text" value="1194"/></label>
-<label><span data-i18n="protocol"></span> <select><option>UDP</option></select></label>
+<label><span data-i18n="protocol"></span> <select><option data-i18n="udp"></option></select></label>
 <label><span data-i18n="status"></span> <select><option data-i18n="on"></option><option data-i18n="off"></option></select></label>
 </section>
 <section style="margin-top:1rem;">
 <h3 data-i18n="login_config"></h3>
 <label><span data-i18n="login_port"></span> <input type="text" value="443"/></label>
-<label><span data-i18n="protocol"></span> <select><option>TCP</option></select></label>
+<label><span data-i18n="protocol"></span> <select><option data-i18n="tcp"></option></select></label>
 <label><span data-i18n="status"></span> <select><option data-i18n="on"></option><option data-i18n="off"></option></select></label>
 <button onclick="showToast(translations[currentLang].applied)" data-i18n="apply"></button>
 <button onclick="showToast(translations[currentLang].test_port)" data-i18n="test_port"></button>

--- a/ui/overview.html
+++ b/ui/overview.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html dir="rtl">
+<html>
 <head>
 <meta charset="utf-8" />
-<title>Overview</title>
+<title data-i18n="overview_title"></title>
 <link rel="stylesheet" href="styles.css" />
 <script src="script.js"></script>
 </head>
@@ -14,8 +14,9 @@
 <h1 data-i18n="sidebar_title"></h1>
 <button onclick="toggleTheme()" data-i18n="btn_theme"></button>
 <select id="langSelect" onchange="setLanguage(this.value)">
-<option value="fa">FA</option>
-<option value="en">EN</option>
+<option value="fa" data-i18n="lang_fa"></option>
+<option value="en" data-i18n="lang_en"></option>
+<option value="ru" data-i18n="lang_ru"></option>
 </select>
 <ul>
 <li><a href="overview.html" data-i18n="nav_overview"></a></li>

--- a/ui/script.js
+++ b/ui/script.js
@@ -104,7 +104,13 @@ const translations = {
     open_firewall: 'باز کردن در فایروال',
     alert_sample: '⚠︎ OpenVPN: ارتباط تونل X قطع شد (5m ago)\nℹ︎ WireGuard: کلید جدید برای کاربر ali ایجاد شد',
     dark: 'دارک',
-    light: 'لایت'
+    light: 'لایت',
+    lang_fa: 'فارسی',
+    lang_en: 'انگلیسی',
+    lang_ru: 'روسی',
+    udp: 'UDP',
+    tcp: 'TCP',
+    tz: 'TZ'
   },
   en: {
     sidebar_title: 'VPN Panel',
@@ -207,9 +213,18 @@ const translations = {
     open_firewall: 'Open in Firewall',
     alert_sample: '⚠︎ OpenVPN: Tunnel X disconnected (5m ago)\nℹ︎ WireGuard: New key generated for user ali',
     dark: 'Dark',
-    light: 'Light'
+    light: 'Light',
+    lang_fa: 'FA',
+    lang_en: 'EN',
+    lang_ru: 'RU',
+    udp: 'UDP',
+    tcp: 'TCP',
+    tz: 'TZ'
   }
 };
+
+// future Russian translations default to English
+translations.ru = { ...translations.en };
 
 let currentLang = localStorage.getItem('lang') || 'fa';
 

--- a/ui/settings.html
+++ b/ui/settings.html
@@ -1,10 +1,11 @@
 <!DOCTYPE html>
-<html dir="rtl">
+<html>
 <head>
 <meta charset="utf-8" />
-<title>General Settings</title>
+<title data-i18n="settings_title"></title>
 <link rel="stylesheet" href="styles.css" />
 <script src="script.js"></script>
+<script src="settings.js"></script>
 </head>
 <body>
 <div class="toast-container"></div>
@@ -14,8 +15,9 @@
 <h1 data-i18n="sidebar_title"></h1>
 <button onclick="toggleTheme()" data-i18n="btn_theme"></button>
 <select id="langSelect" onchange="setLanguage(this.value)">
-<option value="fa">FA</option>
-<option value="en">EN</option>
+<option value="fa" data-i18n="lang_fa"></option>
+<option value="en" data-i18n="lang_en"></option>
+<option value="ru" data-i18n="lang_ru"></option>
 </select>
 <ul>
 <li><a href="overview.html" data-i18n="nav_overview"></a></li>
@@ -37,9 +39,9 @@
 </section>
 <section style="margin-top:1rem;">
 <h3 data-i18n="display_language"></h3>
-<label><span data-i18n="btn_language"></span> <select><option value="fa">FA</option><option value="en">EN</option></select></label>
+<label><span data-i18n="btn_language"></span> <select id="displayLang" onchange="setLanguage(this.value)"><option value="fa" data-i18n="lang_fa"></option><option value="en" data-i18n="lang_en"></option><option value="ru" data-i18n="lang_ru"></option></select></label>
 <label><span data-i18n="btn_theme"></span> <select><option value="dark" data-i18n="dark"></option><option value="light" data-i18n="light"></option></select></label>
-<label><span data-i18n="timezone"></span> <select><option>TZ</option></select></label>
+<label><span data-i18n="timezone"></span> <select><option data-i18n="tz"></option></select></label>
 </section>
 <section style="margin-top:1rem;">
 <h3 data-i18n="network_ports"></h3>

--- a/ui/settings.js
+++ b/ui/settings.js
@@ -1,0 +1,4 @@
+document.addEventListener('DOMContentLoaded', () => {
+  // ensure translations apply to dynamically added settings elements
+  setLanguage(currentLang);
+});

--- a/ui/users.html
+++ b/ui/users.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html dir="rtl">
+<html>
 <head>
 <meta charset="utf-8" />
-<title>Users</title>
+<title data-i18n="users_title"></title>
 <link rel="stylesheet" href="styles.css" />
 <script src="script.js"></script>
 </head>
@@ -23,8 +23,9 @@
 <h1 data-i18n="sidebar_title"></h1>
 <button onclick="toggleTheme()" data-i18n="btn_theme"></button>
 <select id="langSelect" onchange="setLanguage(this.value)">
-<option value="fa">FA</option>
-<option value="en">EN</option>
+<option value="fa" data-i18n="lang_fa"></option>
+<option value="en" data-i18n="lang_en"></option>
+<option value="ru" data-i18n="lang_ru"></option>
 </select>
 <ul>
 <li><a href="overview.html" data-i18n="nav_overview"></a></li>

--- a/ui/wireguard.html
+++ b/ui/wireguard.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html dir="rtl">
+<html>
 <head>
 <meta charset="utf-8" />
-<title>WireGuard Settings</title>
+<title data-i18n="wireguard_title"></title>
 <link rel="stylesheet" href="styles.css" />
 <script src="script.js"></script>
 </head>
@@ -14,8 +14,9 @@
 <h1 data-i18n="sidebar_title"></h1>
 <button onclick="toggleTheme()" data-i18n="btn_theme"></button>
 <select id="langSelect" onchange="setLanguage(this.value)">
-<option value="fa">FA</option>
-<option value="en">EN</option>
+<option value="fa" data-i18n="lang_fa"></option>
+<option value="en" data-i18n="lang_en"></option>
+<option value="ru" data-i18n="lang_ru"></option>
 </select>
 <ul>
 <li><a href="overview.html" data-i18n="nav_overview"></a></li>


### PR DESCRIPTION
## Summary
- mark titles, options, and language selectors with data-i18n across the UI
- add translation keys for language names, protocols, and timezone placeholder; seed Russian locale
- include settings.js to reapply translations on the settings page

## Testing
- `pytest`
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_b_689b370f33048331a0522c6234746abc