### PR TITLE
feat: show login info with default creds

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -462,7 +462,8 @@ function show_completion_info() {
     echo -e "Login Page: ${YELLOW}http://$(hostname -I | awk '{print $1}'):$API_PORT/${NC}"
     echo -e "API URL: ${YELLOW}http://$(hostname -I | awk '{print $1}'):$API_PORT${NC}"
     echo -e "Health Check: ${YELLOW}http://$(hostname -I | awk '{print $1}'):$API_PORT/api/health${NC}"
-    echo -e "\n${YELLOW}Default username/password: admin/admin${NC}"
+    echo -e "\n${YELLOW}Default Username: admin${NC}"
+    echo -e "${YELLOW}Default Password: admin${NC}"
     echo -e "${YELLOW}Please change the default password immediately from the panel.${NC}"
     
     echo -e "\n${BLUE}=== CLI ACCESS ===${NC}"


### PR DESCRIPTION
## Summary
- clarify installation completion message with login page URL
- show default admin credentials and warn to change password

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689b3f250f448331910c5cdc10c17b91