### PR TITLE
fix indentation for profile config route

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -61,7 +61,7 @@ def create_app() -> Flask:
 
         return profile_data(profile_token)
 
- @app.route('/profile/<profile_token>/config.ovpn')
+    @app.route('/profile/<profile_token>/config.ovpn')
     def download_ovpn_config(profile_token):
         """Download OpenVPN config - delegate to profile routes."""
         from .routes.profile_routes import download_ovpn_config as download_config


### PR DESCRIPTION
## Summary
- standardize indentation for profile config download route

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689c2fb12d8c833191d00fae3008f672