### PR TITLE
Ensure on_connect script locates config package

### DIFF
--- a/scripts/on_connect.py
+++ b/scripts/on_connect.py
@@ -7,6 +7,9 @@ import os
 import sys
 import sqlite3
 from datetime import datetime
+project_root = os.environ.get("PROJECT_ROOT", "/etc/owpanel")
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
 from config.paths import VPNPaths
 
 def load_env_vars():


### PR DESCRIPTION
## Summary
- insert project root into `sys.path` so `config` package can be imported by `on_connect` script

## Testing
- `pytest`
- `service openvpn restart` *(fails: openvpn: unrecognized service)*

------
https://chatgpt.com/codex/tasks/task_b_689c3cf8e0fc83319610068d4840796a