### PR TITLE
Use centralized script paths for monitoring

### DIFF
--- a/core/openvpn_manager.py
+++ b/core/openvpn_manager.py
@@ -753,11 +753,14 @@ verb 3"""
         else:
             uds_socket = "/run/openvpn-server/ovpn-mgmt-cert.sock"
 
+        on_connect_script = VPNPaths.get_on_connect_script()
+        on_disconnect_script = VPNPaths.get_on_disconnect_script()
+
         return f"""
 # --- Traffic Monitoring Config ---
 script-security 2
-client-connect /etc/openvpn/scripts/on_connect.py
-client-disconnect /etc/openvpn/scripts/on_disconnect.py
+client-connect {on_connect_script}
+client-disconnect {on_disconnect_script}
 management {uds_socket} unix
 """
 


### PR DESCRIPTION
## Summary
- Load on-connect and on-disconnect script paths from `VPNPaths` instead of hardcoded values
- Generate OpenVPN configs using the centralized script paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689c5372f7948331bd7dc11a744f38ef