### PR TITLE
Handle permission errors when loading env vars

### DIFF
--- a/scripts/on_connect.py
+++ b/scripts/on_connect.py
@@ -16,12 +16,26 @@ def load_env_vars():
     """Load environment variables from .env file."""
     env_file = os.path.join(os.path.dirname(__file__), '..', '.env')
     if os.path.exists(env_file):
-        with open(env_file, 'r') as f:
-            for line in f:
-                line = line.strip()
-                if line and not line.startswith('#') and '=' in line:
-                    key, value = line.split('=', 1)
-                    os.environ[key] = value
+        try:
+            with open(env_file, 'r') as f:
+                for line in f:
+                    line = line.strip()
+                    if line and not line.startswith('#') and '=' in line:
+                        key, value = line.split('=', 1)
+                        os.environ[key] = value
+        except PermissionError:
+            log_file = get_log_file()
+            log_dir = os.path.dirname(log_file)
+            try:
+                os.makedirs(log_dir, exist_ok=True)
+            except Exception:
+                pass
+            timestamp = datetime.now().isoformat()
+            try:
+                with open(log_file, 'a') as log:
+                    log.write(f"{timestamp} - WARNING: Unable to read env file '{env_file}' (permission denied)\n")
+            except Exception:
+                pass
 
 def get_log_file():
     return os.environ.get('OPENVPN_LOG_FILE', '/var/log/openvpn/traffic_monitor.log')


### PR DESCRIPTION
## Summary
- log a warning instead of raising when `.env` can't be read so quota checks continue

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689c5f32442483319d79ef47103c6cab