### PR TITLE
Handle env permission errors and fix symlink uninstall

### DIFF
--- a/core/openvpn_manager.py
+++ b/core/openvpn_manager.py
@@ -599,7 +599,11 @@ tls-version-min 1.2
             "/var/run/openvpn",
         ]
         for path in directories_to_remove:
-            if os.path.exists(path):
+            if not os.path.exists(path):
+                continue
+            if os.path.islink(path) or os.path.isfile(path):
+                os.remove(path)
+            else:
                 shutil.rmtree(path)
 
         if not silent:

--- a/deploy.sh
+++ b/deploy.sh
@@ -192,8 +192,8 @@ QUOTA_BUFFER_BYTES=20971520
 MAX_LOG_SIZE=10485760
 EOF
     
-    # Set secure permissions
-    chmod 600 "$ENV_FILE"
+    # Set permissions so OpenVPN hooks can read the file
+    chmod 755 "$ENV_FILE"
     chown root:root "$ENV_FILE"
     
     print_success "Environment configuration created"

--- a/scripts/on_disconnect.py
+++ b/scripts/on_disconnect.py
@@ -12,15 +12,35 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from data.db import Database
 
 def load_env_vars():
-    """Load environment variables from .env file."""
+    """Load environment variables from .env file.
+
+    If the file exists but isn't readable, log a warning instead of failing.
+    """
     env_file = os.path.join(os.path.dirname(__file__), '..', '.env')
     if os.path.exists(env_file):
-        with open(env_file, 'r') as f:
-            for line in f:
-                line = line.strip()
-                if line and not line.startswith('#') and '=' in line:
-                    key, value = line.split('=', 1)
-                    os.environ[key] = value
+        try:
+            with open(env_file, 'r') as f:
+                for line in f:
+                    line = line.strip()
+                    if line and not line.startswith('#') and '=' in line:
+                        key, value = line.split('=', 1)
+                        os.environ[key] = value
+        except PermissionError:
+            log_file = get_log_file()
+            log_dir = os.path.dirname(log_file)
+            try:
+                os.makedirs(log_dir, exist_ok=True)
+            except Exception:
+                pass
+            timestamp = datetime.now().isoformat()
+            try:
+                with open(log_file, 'a') as log:
+                    log.write(
+                        f"{timestamp} - WARNING: Unable to read env file '{env_file}' "
+                        "(permission denied). Ensure proper file permissions.\n"
+                    )
+            except Exception:
+                pass
 
 def get_log_file():
     return os.environ.get('OPENVPN_LOG_FILE', '/var/log/openvpn/traffic_monitor.log')


### PR DESCRIPTION
## Summary
- log a warning instead of aborting when on_disconnect.py can't read the .env file
- set deploy.sh to install .env with 755 permissions so hooks can read it
- ensure uninstall_openvpn removes symlink directories instead of erroring

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689c68ff3b788331b2fea634c8607dff