### PR TITLE
feat: auto-tune concurrency

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -4,6 +4,7 @@ import sys
 from flask import Flask, send_from_directory, request, redirect, url_for
 from flask_cors import CORS
 
+
 from .routes.user_routes import user_bp
 from .routes.quota_routes import quota_bp
 from .routes.system_routes import system_bp
@@ -116,17 +117,24 @@ def main() -> None:
 
     app = create_app()
     port = int(os.environ.get("API_PORT", 5000))
+
+    def calculate_optimal_threads() -> int:
+        """Determine a sensible Waitress thread count based on CPU cores."""
+        cores = os.cpu_count() or 1
+        # Allow multiple concurrent connections per core but cap to avoid exhaustion
+        return max(4, min(32, cores * 2))
+
     print(f"🚀 Starting OpenVPN Manager API Server on http://0.0.0.0:{port}")
     print(f"🔗 API Endpoints: http://YOUR_IP:{port}/api")
     print(f"📊 Health Check: http://YOUR_IP:{port}/api/health")
 
     from waitress import serve
     import logging
-    
+
     # Suppress Waitress queue warnings
     logging.getLogger('waitress.queue').setLevel(logging.ERROR)
 
-    serve(app, host="0.0.0.0", port=port, threads=4)
+    serve(app, host="0.0.0.0", port=port, threads=calculate_optimal_threads())
 
 
 if __name__ == "__main__":

--- a/api/routes/auth_routes.py
+++ b/api/routes/auth_routes.py
@@ -87,7 +87,8 @@ def logout():
         token = JWTMiddleware._extract_token(request)
         auth_service = g.auth_service
         result = auth_service.logout(token)
-        resp = make_response(jsonify(result), 200)
+        response_data = result if isinstance(result, dict) else {"message": "Logged out"}
+        resp = make_response(jsonify(response_data), 200)
         resp.delete_cookie('token')
         return resp
     except Exception as e:

--- a/data/db.py
+++ b/data/db.py
@@ -1,9 +1,11 @@
-import sqlite3
 import os
-from typing import List, Dict, Any, Tuple, Optional
-from core.types import DatabaseResult, DatabaseRow
+import queue
+import sqlite3
+import threading
+from typing import Any, Dict, List, Optional, Tuple
+
 from core.exceptions import DatabaseError
-from config.env_loader import get_config_value
+from core.types import DatabaseResult
 
 # Use VPNPaths for consistent path management
 from config.paths import VPNPaths
@@ -12,35 +14,66 @@ DATABASE_DIR = VPNPaths.get_database_dir()
 DATABASE_FILE = VPNPaths.get_database_file()
 
 class Database:
-    """
-    Handles all low-level interactions with the SQLite database.
-    """
-    def __init__(self, db_file: str = DATABASE_FILE) -> None:
-        """
-        Initializes the database connection.
+    """Handles all low-level interactions with the SQLite database."""
 
-        Args:
-            db_file (str): The path to the SQLite database file.
-        """
+    # Connection pools per database file
+    _pools: Dict[str, queue.Queue] = {}
+    _locks: Dict[str, threading.Lock] = {}
+
+    def __init__(self, db_file: str = DATABASE_FILE) -> None:
+        """Initialize the database connection and pool."""
+
         self.db_file = db_file
-        # Ensure the directory for the database exists before connecting.
         os.makedirs(os.path.dirname(self.db_file), exist_ok=True)
         self.conn: Optional[sqlite3.Connection] = None
 
+        # Ensure a pool exists for this database file
+        if db_file not in Database._locks:
+            Database._locks[db_file] = threading.Lock()
+        self._ensure_pool()
+
+    # Internal helpers -------------------------------------------------
+
+    def _ensure_pool(self) -> None:
+        """Create a connection pool for the database file if needed."""
+        if self.db_file in Database._pools:
+            return
+        with Database._locks[self.db_file]:
+            if self.db_file in Database._pools:
+                return
+            pool = queue.Queue(maxsize=self._calculate_pool_size())
+            for _ in range(pool.maxsize):
+                conn = sqlite3.connect(self.db_file, check_same_thread=False)
+                conn.row_factory = sqlite3.Row
+                pool.put(conn)
+            Database._pools[self.db_file] = pool
+
+    def _get_from_pool(self) -> sqlite3.Connection:
+        self._ensure_pool()
+        return Database._pools[self.db_file].get()
+
+    def _return_to_pool(self, conn: sqlite3.Connection) -> None:
+        self._ensure_pool()
+        Database._pools[self.db_file].put(conn)
+
+    def _calculate_pool_size(self) -> int:
+        """Determine an appropriate connection pool size."""
+        cores = os.cpu_count() or 1
+        # Provide multiple connections per core but avoid excessive handles
+        return max(5, min(100, cores * 5))
+
     def connect(self) -> None:
-        """Establishes a connection to the database."""
-        try:
-            # The check_same_thread=False is important for applications
-            # where different threads might interact with the database.
-            self.conn = sqlite3.connect(self.db_file, check_same_thread=False)
-            self.conn.row_factory = sqlite3.Row
-        except sqlite3.Error as e:
-            raise DatabaseError(f"Failed to connect to database: {e}")
+        """Retrieve a connection from the pool."""
+        if not self.conn:
+            try:
+                self.conn = self._get_from_pool()
+            except sqlite3.Error as e:
+                raise DatabaseError(f"Failed to retrieve database connection: {e}")
 
     def disconnect(self) -> None:
-        """Closes the database connection."""
+        """Return the connection to the pool."""
         if self.conn:
-            self.conn.close()
+            self._return_to_pool(self.conn)
             self.conn = None
 
     def execute_query(self, query: str, params: Tuple = ()) -> DatabaseResult:
@@ -101,20 +134,20 @@ class Database:
             def __init__(self, db_instance):
                 self.db = db_instance
                 self.conn = None
-            
+
             def __enter__(self):
                 self.db.connect()
                 self.conn = self.db.conn
                 return self.conn
-            
+
             def __exit__(self, exc_type, exc_val, exc_tb):
                 if self.conn:
                     if exc_type:
                         self.conn.rollback()
                     else:
                         self.conn.commit()
-                    self.conn.close()
+                    self.db._return_to_pool(self.conn)
                     self.conn = None
                 self.db.conn = None
-        
+
         return ConnectionContext(self)


### PR DESCRIPTION
## Summary
- calculate Waitress threads from CPU cores automatically
- size SQLite connection pool dynamically based on available cores
- remove optional environment variable docs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a8b149eeb88331bb8f45947ace7e5f